### PR TITLE
Add prefix option and slack color

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Role Variables
 ```yaml
 s3_user_name: # Required, user name to associate with key, is reported to slack on failure
 s3_user_bucket: # Required, bucket to run list operation against, access key must have Get/List perms on bucket
+s3_user_prefix: # Optional but highly recommended if the bucket has a large number of files on the root, create an empty folder and use it as prefix, otherwise this role will take a long time to execute.
 s3_user_access_key: # Optional, can also be supplied by Ansible Tower Credential
 s3_user_secret_key: # Optional, can also be supplied by Ansible Tower Credential
 s3_user_local_support: # Optional, contact that is listed in Slack error message
@@ -28,6 +29,7 @@ s3_user_local_support: # Optional, contact that is listed in Slack error message
 s3_user_slack_token:
 s3_user_slack_msg:
 s3_user_slack_channel:
+s3_user_slack_color:
 s3_user_slack_thread_id:
 s3_user_slack_username:
 s3_user_slack_icon_url:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 # defaults file for emorylib_s3_test_access_key
+s3_user_slack_color: danger

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,9 +7,8 @@
         aws_access_key: '{{ s3_user_access_key | d (omit) }}'
         aws_secret_key: '{{ s3_user_secret_key | d (omit) }}'
         bucket: '{{ s3_user_bucket }}'
+        prefix: '{{ s3_user_prefix | d (omit) }}'
         mode: list
-        max_keys: 1
-      register: list_info
   rescue:
     - name: Build error message report
       set_fact:
@@ -32,6 +31,7 @@
         token: '{{ s3_user_slack_token }}'
         msg: '{{ s3_user_slack_msg | d (omit) }}'
         channel: '{{ s3_user_slack_channel | d (omit) }}'
+        color: '{{ s3_user_slack_color | d (omit) }}'
         thread_id: '{{ s3_user_slack_thread_id | d (omit) }}'
         username: '{{ s3_user_slack_username | d (omit) }}'
         icon_url: '{{ s3_user_slack_icon_url | d (omit) }}'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,0 @@
----
-# vars file for emorylib_s3_test_access_key


### PR DESCRIPTION
This commit adds the prefix option for specifying a bucket folder, useful if the root of the bucket is heavily populated with files, in that case, create an empty folder and use that as a prefix to avoid this role taking 5+ minutes to execute.